### PR TITLE
Improved Zip Archive Build

### DIFF
--- a/build_linux.bash
+++ b/build_linux.bash
@@ -119,7 +119,11 @@ fi
 
 
 package() {
-    7z a -tzip Drill-$1-linux-$DRILL_VERSION-x86_64.zip assets drill-$1 DRILL_VERSION  $OUTPUT
+    mkdir Drill-$1-linux-$DRILL_VERSION-x86_64
+    mv assets Drill-$1-linux-$DRILL_VERSION-x86_64
+    mv drill-$1 Drill-$1-linux-$DRILL_VERSION-x86_64
+    mv DRILL_VERSION Drill-$1-linux-$DRILL_VERSION-x86_64
+    7z a -tzip Drill-$1-linux-$DRILL_VERSION-x86_64.zip Drill-$1-linux-$DRILL_VERSION-x86_64  $OUTPUT
     if [ $? -eq 0 ]; then
         info "Zipping of $1 done"
         mv Drill-$1-linux-$DRILL_VERSION-x86_64.zip build $OUTPUT


### PR DESCRIPTION
Previously the zip build would just add the assets and binaries directly to the zip file. This means when you extract it, it's not in one folder it extracts the assets folder, binaries and what not individually. Traditionally in a zip or tarball release, all the assets are placed in a root folder with the name of the release. Look at Firefox Nightly releases for Linux for example. This fixes it by creating a root folder based on the release version then moving the assets and binaries into it, then archiving that folder.